### PR TITLE
Change functionality to work with split string instead of reg matching

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,8 +38,8 @@ body:
 - type: checkboxes
   id: testing
   attributes:
-    label: Tested with only AdiBags_Bound
-    description: Did you try having AdiBags and AdiBags_Bound as the only enabled addons and everything else (especially other AdiBags plugins) disabled?
+    label: Tested with only AdiBags_TradeableLoot
+    description: Did you try having AdiBags and AdiBags_TradeableLoot as the only enabled addons and everything else (especially other AdiBags plugins) disabled?
     options:
       - label: "Yes"
       - label: "No"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .release/
+*.zip

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,8 +1,8 @@
-package-as: AdiBags_Bound
+package-as: AdiBags_TradeableLoot
 enable-nolib-creation: no
 
 move-folders:
-    AdiBags_Bound/AdiBags_Bound: AdiBags_Bound
+    AdiBags_TradeableLoot/AdiBags_TradeableLoot: AdiBags_TradeableLoot
 
 manual-changelog:
     filename: CHANGELOG.md

--- a/AdiBags_TradeableLoot/AdiBags_TradeableLoot.toc
+++ b/AdiBags_TradeableLoot/AdiBags_TradeableLoot.toc
@@ -1,6 +1,6 @@
 ## Interface: 100100
 
-## Title: AdiBags - Bound
+## Title: AdiBags - TradeableLoot
 ## Notes: Adds BoE/BoA/BoP filters to AdiBags.
 ## Author: Avyiel, Spanky, Outroot
 ## Version: @project-version@

--- a/AdiBags_TradeableLoot/AdiBags_TradeableLoot_Classic.toc
+++ b/AdiBags_TradeableLoot/AdiBags_TradeableLoot_Classic.toc
@@ -1,6 +1,6 @@
-## Interface: 30401
+## Interface: 11403
 
-## Title: AdiBags - Bound
+## Title: AdiBags - TradeableLoot
 ## Notes: Adds BoE/BoA/BoP filters to AdiBags.
 ## Author: Avyiel, Spanky, Outroot
 ## Version: @project-version@

--- a/AdiBags_TradeableLoot/AdiBags_TradeableLoot_Wrath.toc
+++ b/AdiBags_TradeableLoot/AdiBags_TradeableLoot_Wrath.toc
@@ -1,6 +1,6 @@
-## Interface: 11403
+## Interface: 30401
 
-## Title: AdiBags - Bound
+## Title: AdiBags - TradeableLoot
 ## Notes: Adds BoE/BoA/BoP filters to AdiBags.
 ## Author: Avyiel, Spanky, Outroot
 ## Version: @project-version@

--- a/AdiBags_TradeableLoot/Main.lua
+++ b/AdiBags_TradeableLoot/Main.lua
@@ -89,12 +89,6 @@ local L = setmetatable({}, {
 L["TradeableLoot"] = true                                              -- uiName
 L["Put BoE and items with a loot Timer in their own sections."] = true -- uiDesc
 
--- Options
-L["Enable BoE"] = true
-L["Check this if you want a section for BoE items."] = true
-L["Enable loot with Timer"] = true
-L["Check this if you want a section for items with a loot timer."] = true
-
 -- Categories
 L[S_BOE] = true
 L[S_TIMER] = true
@@ -126,39 +120,6 @@ function filter:OnInitialize()
 	})
 end
 
--- Setup options panel
-function filter:GetOptions()
-	return {
-		enableBoE = {
-			name = L["Enable BoE"],
-			desc = L["Check this if you want a section for BoE items."],
-			type = "toggle",
-			width = "double",
-			order = 10,
-		},
-		enableTimer = {
-			name = L["Enable loot with Timer"],
-			desc = L["Check this if you want a section for items with a loot timer."],
-			type = "toggle",
-			width = "double",
-			order = 15,
-		},
-	}, AdiBags:GetOptionHandler(self, true, function() return self:Update() end)
-end
-
-function filter:Update()
-	-- Notify myself that the filtering options have changed
-	self:SendMessage("AdiBags_FiltersChanged")
-end
-
-function filter:OnEnable()
-	AdiBags:UpdateFilters()
-end
-
-function filter:OnDisable()
-	AdiBags:UpdateFilters()
-end
-
 -----------------------------------------------------------
 -- Actual filter
 -----------------------------------------------------------
@@ -178,7 +139,7 @@ function filter:Filter(slotData)
 
 	-- Only parse items that are Uncommon (2) and above, and are of type BoP, BoE
 	local junk = quality ~= nil and quality <= 1
-	if (not junk or (junk and self.db.profile.grayAndWhiteBoE)) or (bindType ~= nil and bindType > 0 and bindType < 3) then
+	if (not junk) or (bindType ~= nil and bindType > 0 and bindType < 3) then
 		local category = self:GetItemCategory(bag, slot)
 		return self:GetCategoryLabel(category, itemId)
 	end

--- a/AdiBags_TradeableLoot/Main.lua
+++ b/AdiBags_TradeableLoot/Main.lua
@@ -126,7 +126,7 @@ end
 
 -- Tooltip used for scanning.
 -- Let's keep this name for all scanner addons.
-local _SCANNER = "AVY_ScannerTooltip"
+local _SCANNER = "TradeableLoot_ScannerTooltip"
 local Scanner
 if not addon.IsRetail then
 	-- This is not needed on WoW10, since we can use C_TooltipInfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# AdiBags Bound Change Log
+# AdiBags TradeableLoot Change Log
 All notable changes to this project will be documented in this file. Be aware that the [Unreleased] features are not yet available in the official tagged builds.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+Copyright (c) 2023 Ella36
 Copyright (c) 2022 Lucas Vienna, Spanky, outroot
 Copyright (c) 2021 Lars Norberg
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AdiBags Bound
+# AdiBags TradeableLoot
 > Filters for BoE, BoA, and Soulbound categories in [AdiBags](https://github.com/AdiAddons/AdiBags).
 
 By default, the addon will only sort BoE and BoA. Soulbound items can be


### PR DESCRIPTION
Fixing error when opening bags in 10.2

Using array length syntax # on the `tooltipInfo.lines` instead of the global scope scanner. And changing the functionality for Timer items to just use a split sub string instead of trying to regmatch %s